### PR TITLE
プロジェクト名の変更とMainActivityのコメント整理

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-ry0000taro.dojo2026
+Gaplay

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
@@ -43,7 +43,6 @@ class MainActivity : ComponentActivity() {
             val navController = rememberNavController()
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-            // --- ★ 修正1: exerciseSeconds を取り出す ---
             val videoList = uiState.videoList
             val isLoading = uiState.isLoading
             val savedQuery = uiState.lastQuery
@@ -70,7 +69,6 @@ class MainActivity : ComponentActivity() {
                                     videoList = videoList,
                                     targetMinutes = savedMinutes,
                                     onVideoSelect = { video ->
-                                        // --- ★ 修正2: 計算ロジックを動かす ---
                                         viewModel.onVideoSelect(video)
                                         navController.navigate("timer_player/${video.id}")
                                     }
@@ -84,7 +82,6 @@ class MainActivity : ComponentActivity() {
                                 TimerPlayerScreen(
                                     video = videoEntity,
                                     remainingSeconds = remainingSeconds,
-                                    // --- ★ 修正3: 計算済みの運動時間を画面に渡す ---
                                     exerciseSeconds = exerciseSeconds,
                                     isExercisePhase = isExercisePhase,
                                     onBack = {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,5 +24,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "ry0000taro.dojo2026"
+rootProject.name = "Gaplay"
 include(":app")


### PR DESCRIPTION
- プロジェクト名を「ry0000taro.dojo2026」から「Gaplay」に変更
- `settings.gradle.kts` および IDE設定ファイルのプロジェクト名を更新
- `MainActivity.kt` 内の不要なコメントを削除