### PR TITLE
動画のフルスクリーン・ミニプレイヤー間の遷移アニメーション追加および状態管理の刷新 

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.converter.gson)
     implementation(libs.retrofit)
+    implementation(libs.okhttp.logging)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
@@ -85,18 +85,10 @@ class MainActivity : ComponentActivity() {
 
                         // --- 【上の層】 プレイヤー・オーバーレイ ---
                         if (uiState.selectedVideo != null) {
-                            val overlayModifier = if (uiState.playerMode == PlayerMode.FULL) {
-                                Modifier.fillMaxSize()
-                            } else {
-                                // ミニプレイヤー時は画面下部に配置し、ボトムバー分浮かせる
-                                Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .padding(bottom = innerPadding.calculateBottomPadding())
-                            }
-
-                            Box(modifier = overlayModifier) {
+                            Box(modifier = Modifier.fillMaxSize()) {
                                 PlayerOverlay(
                                     uiState = uiState,
+                                    bottomPadding = innerPadding.calculateBottomPadding(),
                                     onCollapse = { viewModel.updatePlayerMode(PlayerMode.MINI) },
                                     onExpand = { viewModel.updatePlayerMode(PlayerMode.FULL) },
                                     onClose = { viewModel.closePlayer() }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
@@ -19,6 +20,8 @@ import com.example.ry0000tarodojo2026.ui.theme.Ry0000tarodojo2026Theme
 import com.example.ry0000tarodojo2026.ui.components.MainBottomBar
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.ry0000tarodojo2026.ui.components.PlayerOverlay
+import com.example.ry0000tarodojo2026.ui.viewmodel.PlayerMode
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -31,49 +34,72 @@ class MainActivity : ComponentActivity() {
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
             Ry0000tarodojo2026Theme {
+                // 全画面表示の時はボトムバーを隠す
+                val showBottomBar = uiState.playerMode != PlayerMode.FULL
+
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
-                    bottomBar = { MainBottomBar(navController = navController) }
+                    bottomBar = {
+                        if (showBottomBar) {
+                            MainBottomBar(navController = navController)
+                        }
+                    }
                 ) { innerPadding ->
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                        color = MaterialTheme.colorScheme.background
-                    ) {
-                        NavHost(navController = navController, startDestination = Routes.SEARCH_LIST) {
-                            composable(Routes.SEARCH_LIST) {
-                                SearchListScreen(
-                                    videoList = uiState.videoList,
-                                    targetMinutes = uiState.lastMinutes,
-                                    exerciseType = uiState.exerciseType,
-                                    initialQuery = uiState.lastQuery,
-                                    isLoading = uiState.isLoading,
-                                    onSearch = { query, seconds, selectedExercise ->
-                                        viewModel.searchVideos(BuildConfig.YOUTUBE_API_KEY, query, seconds, selectedExercise)
-                                    },
-                                    onVideoSelect = { video ->
-                                        viewModel.onVideoSelect(video)
-                                        navController.navigate("timer_player/${video.id}")
-                                    }
-                                )
+                    // Boxでメインコンテンツとプレイヤーを重ねる
+                    Box(modifier = Modifier.fillMaxSize()) {
+
+                        // --- 【下の層】 画面遷移エリア ---
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(innerPadding),
+                            color = MaterialTheme.colorScheme.background
+                        ) {
+                            NavHost(
+                                navController = navController,
+                                startDestination = Routes.SEARCH_LIST
+                            ) {
+                                composable(Routes.SEARCH_LIST) {
+                                    SearchListScreen(
+                                        videoList = uiState.videoList,
+                                        targetMinutes = uiState.lastMinutes,
+                                        exerciseType = uiState.exerciseType,
+                                        initialQuery = uiState.lastQuery,
+                                        isLoading = uiState.isLoading,
+                                        onSearch = { query, seconds, selectedExercise ->
+                                            viewModel.searchVideos(
+                                                BuildConfig.YOUTUBE_API_KEY,
+                                                query,
+                                                seconds,
+                                                selectedExercise
+                                            )
+                                        },
+                                        onVideoSelect = { video ->
+                                            // 画面遷移せず、状態を更新してプレイヤーを表示
+                                            viewModel.onVideoSelect(video)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        // --- 【上の層】 プレイヤー・オーバーレイ ---
+                        if (uiState.selectedVideo != null) {
+                            val overlayModifier = if (uiState.playerMode == PlayerMode.FULL) {
+                                Modifier.fillMaxSize()
+                            } else {
+                                // ミニプレイヤー時は画面下部に配置し、ボトムバー分浮かせる
+                                Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .padding(bottom = innerPadding.calculateBottomPadding())
                             }
 
-                            composable("timer_player/{videoId}") { backStackEntry ->
-                                val timerViewModel: TimerViewModel = hiltViewModel()
-                                val videoId = backStackEntry.arguments?.getString("videoId") ?: ""
-                                val videoEntity by timerViewModel.getVideoById(videoId).collectAsState(initial = null)
-
-                                TimerPlayerScreen(
-                                    video = videoEntity,
-                                    remainingSeconds = uiState.remainingSeconds,
-                                    exerciseSeconds = uiState.exerciseSeconds,
-                                    isExercisePhase = uiState.isExercisePhase,
-                                    exerciseType = uiState.exerciseType,
-                                    onBack = {
-                                        viewModel.onBackToList()
-                                        navController.popBackStack()
-                                    }
+                            Box(modifier = overlayModifier) {
+                                PlayerOverlay(
+                                    uiState = uiState,
+                                    onCollapse = { viewModel.updatePlayerMode(PlayerMode.MINI) },
+                                    onExpand = { viewModel.updatePlayerMode(PlayerMode.FULL) },
+                                    onClose = { viewModel.closePlayer() }
                                 )
                             }
                         }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/api/RetrofitInstance.kt
@@ -1,14 +1,25 @@
 package com.example.ry0000tarodojo2026.data.api
 
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitInstance {
     private const val BASE_URL = "https://www.googleapis.com/youtube/v3/"
+    private val client: OkHttpClient by lazy {
+        val logging = HttpLoggingInterceptor()
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY)
+
+        OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+    }
 
     val api: YouTubeApiService by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(client) // カスタムしたOkHttpClientをセット
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(YouTubeApiService::class.java)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/api/RetrofitInstance.kt
@@ -4,16 +4,18 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import com.example.ry0000tarodojo2026.BuildConfig
 
 object RetrofitInstance {
     private const val BASE_URL = "https://www.googleapis.com/youtube/v3/"
     private val client: OkHttpClient by lazy {
-        val logging = HttpLoggingInterceptor()
-        logging.setLevel(HttpLoggingInterceptor.Level.BODY)
-
-        OkHttpClient.Builder()
-            .addInterceptor(logging)
-            .build()
+        val builder = OkHttpClient.Builder()
+        if (BuildConfig.DEBUG) {
+            val logging = HttpLoggingInterceptor()
+            logging.setLevel(HttpLoggingInterceptor.Level.BODY)
+            builder.addInterceptor(logging)
+        }
+        builder.build()
     }
 
     val api: YouTubeApiService by lazy {

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
@@ -19,7 +19,8 @@ import com.example.ry0000tarodojo2026.data.model.VideoEntity
 fun MiniPlayerBar(
     video: VideoEntity?,
     onExpand: () -> Unit,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    videoPlayerContent: @Composable () -> Unit
     ){
     if (video == null) return
 
@@ -40,10 +41,7 @@ fun MiniPlayerBar(
                     .width(110.dp)
                     .fillMaxHeight()
             ) {
-                VideoPlayerView(
-                    videoId = video.id,
-                    modifier = Modifier.fillMaxSize()
-                )
+                videoPlayerContent()
             }
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
@@ -35,14 +35,16 @@ fun MiniPlayerBar(
             modifier = Modifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically
         ){
-            AsyncImage(
-                model = video.thumbnailUrl,
-                contentDescription = null,
-                modifier = Modifier.width(110.dp)
-                    .fillMaxHeight(),
-                contentScale = ContentScale.Crop
-            )
-
+            Box(
+                modifier = Modifier
+                    .width(110.dp)
+                    .fillMaxHeight()
+            ) {
+                VideoPlayerView(
+                    videoId = video.id,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
             Column(
                 modifier = Modifier
                     .weight(1f)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
@@ -1,0 +1,72 @@
+package com.example.ry0000tarodojo2026.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.ry0000tarodojo2026.data.model.VideoEntity
+
+@Composable
+fun MiniPlayerBar(
+    video: VideoEntity?,
+    onExpand: () -> Unit,
+    onClose: () -> Unit
+    ){
+    if (video == null) return
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .clickable{ onExpand()},
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shadowElevation = 8.dp
+    ){
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            AsyncImage(
+                model = video.thumbnailUrl,
+                contentDescription = null,
+                modifier = Modifier.width(110.dp)
+                    .fillMaxHeight(),
+                contentScale = ContentScale.Crop
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp)
+            ){
+                Text(
+                    text = video.title,
+                    style= MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = video.channelTitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            IconButton(onClick = onClose){
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close Player"
+                )
+        }
+        }
+    }
+}

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/MiniPlayerBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,10 +19,12 @@ import com.example.ry0000tarodojo2026.data.model.VideoEntity
 @Composable
 fun MiniPlayerBar(
     video: VideoEntity?,
+    isExercisePhase: Boolean = false,
     onExpand: () -> Unit,
     onClose: () -> Unit,
+    sharedBoundsModifier: Modifier = Modifier,
     videoPlayerContent: @Composable () -> Unit
-    ){
+){
     if (video == null) return
 
     Surface(
@@ -40,25 +43,47 @@ fun MiniPlayerBar(
                 modifier = Modifier
                     .width(110.dp)
                     .fillMaxHeight()
+                    .then(sharedBoundsModifier)
             ) {
-                videoPlayerContent()
+                if (isExercisePhase) {
+                    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.tertiaryContainer), contentAlignment = Alignment.Center) {
+                        Icon(Icons.Default.FitnessCenter, contentDescription = null, tint = MaterialTheme.colorScheme.onTertiaryContainer)
+                    }
+                } else {
+                    videoPlayerContent()
+                }
             }
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 12.dp)
             ){
-                Text(
-                    text = video.title,
-                    style= MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Text(
-                    text = video.channelTitle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                if (isExercisePhase) {
+                    Text(
+                        text = "EXERCISE TIME!",
+                        style= MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = "Keep it up!",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = video.title,
+                        style= MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = video.channelTitle,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
 
             IconButton(onClick = onClose){

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -1,0 +1,35 @@
+package com.example.ry0000tarodojo2026.ui.components
+
+import androidx.compose.runtime.Composable
+import com.example.ry0000tarodojo2026.ui.screens.TimerPlayerScreen
+import com.example.ry0000tarodojo2026.ui.viewmodel.MainUiState
+import com.example.ry0000tarodojo2026.ui.viewmodel.PlayerMode
+
+@Composable
+fun PlayerOverlay(
+    uiState: MainUiState,
+    onCollapse: () -> Unit,
+    onExpand: () -> Unit,
+    onClose: () -> Unit
+) {
+    when (uiState.playerMode){
+        PlayerMode.FULL -> {
+            TimerPlayerScreen(
+                video = uiState.selectedVideo,
+                remainingSeconds = uiState.remainingSeconds,
+                exerciseSeconds = uiState.exerciseSeconds,
+                isExercisePhase = uiState.isExercisePhase,
+                exerciseType = uiState.exerciseType,
+                onBack = onCollapse
+            )
+        }
+        PlayerMode.MINI -> {
+            MiniPlayerBar(
+                video = uiState.selectedVideo,
+                onExpand = onExpand,
+                onClose = onClose
+            )
+        }
+        PlayerMode.HIDDEN -> {/*何も表示しない*/}
+    }
+}

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -1,6 +1,10 @@
 package com.example.ry0000tarodojo2026.ui.components
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.ui.Modifier
 import com.example.ry0000tarodojo2026.ui.screens.TimerPlayerScreen
 import com.example.ry0000tarodojo2026.ui.viewmodel.MainUiState
 import com.example.ry0000tarodojo2026.ui.viewmodel.PlayerMode
@@ -12,6 +16,17 @@ fun PlayerOverlay(
     onExpand: () -> Unit,
     onClose: () -> Unit
 ) {
+    val videoId = uiState.selectedVideo?.id
+    val videoPlayer = remember(videoId) {
+        movableContentOf {
+            if (videoId != null) {
+                VideoPlayerView(
+                    videoId = videoId,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
     when (uiState.playerMode){
         PlayerMode.FULL -> {
             TimerPlayerScreen(
@@ -20,14 +35,16 @@ fun PlayerOverlay(
                 exerciseSeconds = uiState.exerciseSeconds,
                 isExercisePhase = uiState.isExercisePhase,
                 exerciseType = uiState.exerciseType,
-                onBack = onCollapse
+                onBack = onCollapse,
+                videoPlayerContent = videoPlayer
             )
         }
         PlayerMode.MINI -> {
             MiniPlayerBar(
                 video = uiState.selectedVideo,
                 onExpand = onExpand,
-                onClose = onClose
+                onClose = onClose,
+                videoPlayerContent = videoPlayer
             )
         }
         PlayerMode.HIDDEN -> {/*何も表示しない*/}

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -1,17 +1,29 @@
 package com.example.ry0000tarodojo2026.ui.components
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
 import com.example.ry0000tarodojo2026.ui.screens.TimerPlayerScreen
 import com.example.ry0000tarodojo2026.ui.viewmodel.MainUiState
 import com.example.ry0000tarodojo2026.ui.viewmodel.PlayerMode
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun PlayerOverlay(
     uiState: MainUiState,
+    bottomPadding: Dp,
     onCollapse: () -> Unit,
     onExpand: () -> Unit,
     onClose: () -> Unit
@@ -27,26 +39,69 @@ fun PlayerOverlay(
             }
         }
     }
-    when (uiState.playerMode){
-        PlayerMode.FULL -> {
-            TimerPlayerScreen(
-                video = uiState.selectedVideo,
-                remainingSeconds = uiState.remainingSeconds,
-                exerciseSeconds = uiState.exerciseSeconds,
-                isExercisePhase = uiState.isExercisePhase,
-                exerciseType = uiState.exerciseType,
-                onBack = onCollapse,
-                videoPlayerContent = videoPlayer
-            )
+
+    SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
+        AnimatedContent(
+            targetState = uiState.playerMode,
+            label = "playerModeTransition"
+        ) { targetMode ->
+            when (targetMode) {
+                PlayerMode.FULL -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .pointerInput(Unit) { detectTapGestures() }
+                    ) {
+                        TimerPlayerScreen(
+                            video = uiState.selectedVideo,
+                            remainingSeconds = uiState.remainingSeconds,
+                            exerciseSeconds = uiState.exerciseSeconds,
+                            isExercisePhase = uiState.isExercisePhase,
+                            exerciseType = uiState.exerciseType,
+                            onBack = onCollapse,
+                            videoPlayerContent = {
+                                Box(
+                                    modifier = Modifier
+                                        .sharedBounds(
+                                            sharedContentState = rememberSharedContentState(key = "video-$videoId"),
+                                            animatedVisibilityScope = this@AnimatedContent
+                                        )
+                                        .fillMaxSize()
+                                ) {
+                                    videoPlayer()
+                                }
+                            }
+                        )
+                    }
+                }
+                PlayerMode.MINI -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(bottom = bottomPadding),
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        MiniPlayerBar(
+                            video = uiState.selectedVideo,
+                            onExpand = onExpand,
+                            onClose = onClose,
+                            videoPlayerContent = {
+                                Box(
+                                    modifier = Modifier
+                                        .sharedBounds(
+                                            sharedContentState = rememberSharedContentState(key = "video-$videoId"),
+                                            animatedVisibilityScope = this@AnimatedContent
+                                        )
+                                        .fillMaxSize()
+                                ) {
+                                    videoPlayer()
+                                }
+                            }
+                        )
+                    }
+                }
+                PlayerMode.HIDDEN -> { /*何も表示しない*/ }
+            }
         }
-        PlayerMode.MINI -> {
-            MiniPlayerBar(
-                video = uiState.selectedVideo,
-                onExpand = onExpand,
-                onClose = onClose,
-                videoPlayerContent = videoPlayer
-            )
-        }
-        PlayerMode.HIDDEN -> {/*何も表示しない*/}
     }
 }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.movableContentOf
@@ -68,7 +70,11 @@ fun PlayerOverlay(
                                         )
                                         .fillMaxSize()
                                 ) {
-                                    videoPlayer()
+                                    if (targetMode == uiState.playerMode) {
+                                        videoPlayer()
+                                    } else {
+                                        Box(modifier = Modifier.fillMaxSize().background(Color.Black))
+                                    }
                                 }
                             }
                         )
@@ -94,7 +100,11 @@ fun PlayerOverlay(
                                         )
                                         .fillMaxSize()
                                 ) {
-                                    videoPlayer()
+                                    if (targetMode == uiState.playerMode) {
+                                        videoPlayer()
+                                    } else {
+                                        Box(modifier = Modifier.fillMaxSize().background(Color.Black))
+                                    }
                                 }
                             }
                         )

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -47,6 +47,10 @@ fun PlayerOverlay(
             targetState = uiState.playerMode,
             label = "playerModeTransition"
         ) { targetMode ->
+            val sharedMod = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "video-$videoId"),
+                animatedVisibilityScope = this@AnimatedContent
+            )
             when (targetMode) {
                 PlayerMode.FULL -> {
                     Box(
@@ -61,16 +65,12 @@ fun PlayerOverlay(
                             isExercisePhase = uiState.isExercisePhase,
                             exerciseType = uiState.exerciseType,
                             onBack = onCollapse,
+                            sharedBoundsModifier = sharedMod,
                             videoPlayerContent = {
                                 Box(
-                                    modifier = Modifier
-                                        .sharedBounds(
-                                            sharedContentState = rememberSharedContentState(key = "video-$videoId"),
-                                            animatedVisibilityScope = this@AnimatedContent
-                                        )
-                                        .fillMaxSize()
+                                    modifier = Modifier.fillMaxSize()
                                 ) {
-                                    if (targetMode == uiState.playerMode) {
+                                    if (targetMode == uiState.playerMode && !uiState.isExercisePhase) {
                                         videoPlayer()
                                     } else {
                                         Box(modifier = Modifier.fillMaxSize().background(Color.Black))
@@ -81,6 +81,10 @@ fun PlayerOverlay(
                     }
                 }
                 PlayerMode.MINI -> {
+                    val sharedMod = Modifier.sharedBounds(
+                        sharedContentState = rememberSharedContentState(key = "video-$videoId"),
+                        animatedVisibilityScope = this@AnimatedContent
+                    )
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -89,18 +93,15 @@ fun PlayerOverlay(
                     ) {
                         MiniPlayerBar(
                             video = uiState.selectedVideo,
+                            isExercisePhase = uiState.isExercisePhase,
                             onExpand = onExpand,
                             onClose = onClose,
+                            sharedBoundsModifier = sharedMod,
                             videoPlayerContent = {
                                 Box(
-                                    modifier = Modifier
-                                        .sharedBounds(
-                                            sharedContentState = rememberSharedContentState(key = "video-$videoId"),
-                                            animatedVisibilityScope = this@AnimatedContent
-                                        )
-                                        .fillMaxSize()
+                                    modifier = Modifier.fillMaxSize()
                                 ) {
-                                    if (targetMode == uiState.playerMode) {
+                                    if (targetMode == uiState.playerMode && !uiState.isExercisePhase) {
                                         videoPlayer()
                                     } else {
                                         Box(modifier = Modifier.fillMaxSize().background(Color.Black))

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -56,7 +58,11 @@ fun PlayerOverlay(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .pointerInput(Unit) { detectTapGestures() }
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = {}
+                            )
                     ) {
                         TimerPlayerScreen(
                             video = uiState.selectedVideo,

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/VideoPlayerView.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/VideoPlayerView.kt
@@ -1,0 +1,37 @@
+package com.example.ry0000tarodojo2026.ui.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+
+@Composable
+fun VideoPlayerView(
+    videoId: String,
+    modifier: Modifier = Modifier
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val videoIdOnly = videoId.trim().split("v=").last().split("&").first().split("/").last()
+
+    AndroidView(
+        factory = { context ->
+            YouTubePlayerView(context).apply {
+                lifecycleOwner.lifecycle.addObserver(this)
+                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
+                    override fun onReady(youTubePlayer: YouTubePlayer) {
+                        youTubePlayer.loadVideo(videoIdOnly, 0f)
+                    }
+                })
+            }
+        },
+        modifier = modifier.fillMaxSize(),
+        onRelease = { view ->
+            lifecycleOwner.lifecycle.removeObserver(view)
+            view.release()
+        }
+    )
+}

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
@@ -47,16 +47,16 @@ fun TimerPlayerScreen(
     exerciseSeconds: Long,
     isExercisePhase: Boolean,
     exerciseType: ExerciseType,
-    onBack: () -> Unit
-) {
-
+    onBack: () -> Unit,
+    videoPlayerContent: @Composable () -> Unit
+)
+{
     if (video == null) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             CircularProgressIndicator()
         }
         return
     }
-
 
     var shakeCount by remember { mutableIntStateOf(0) }
     var isSensorAvailable by remember { mutableStateOf(true) }
@@ -271,7 +271,7 @@ fun TimerPlayerScreen(
                 contentAlignment = Alignment.Center
             ) {
                 if (!isExercisePhase) {
-                   VideoPlayerView(videoId = video.id)
+                   videoPlayerContent()
                 } else {
                     // 運動中（WORKOUT）の表示
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
@@ -35,6 +35,7 @@ import android.hardware.SensorManager
 import com.example.ry0000tarodojo2026.R
 import com.example.ry0000tarodojo2026.data.model.ExerciseType
 import com.example.ry0000tarodojo2026.data.model.VideoEntity
+import com.example.ry0000tarodojo2026.ui.components.VideoPlayerView
 import com.example.ry0000tarodojo2026.utils.ShakeDetector
 import java.util.Locale
 
@@ -48,8 +49,6 @@ fun TimerPlayerScreen(
     exerciseType: ExerciseType,
     onBack: () -> Unit
 ) {
-    // 画面の「寿命（ライフサイクル）」を管理するオブジェクトを取得
-    val lifecycleOwner = LocalLifecycleOwner.current
 
     if (video == null) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -58,10 +57,6 @@ fun TimerPlayerScreen(
         return
     }
 
-    // YouTubeの動画IDのみを抽出（URL形式でもID形式でも対応）
-    val videoIdOnly = remember(video.id) {
-        video.id.trim().split("v=").last().split("&").first().split("/").last()
-    }
 
     var shakeCount by remember { mutableIntStateOf(0) }
     var isSensorAvailable by remember { mutableStateOf(true) }
@@ -276,28 +271,7 @@ fun TimerPlayerScreen(
                 contentAlignment = Alignment.Center
             ) {
                 if (!isExercisePhase) {
-                    AndroidView(
-                        factory = { context ->
-                            YouTubePlayerView(context).apply {
-                                // アプリのライフサイクル（停止・再開）とプレーヤーを連動させる
-                                lifecycleOwner.lifecycle.addObserver(this)
-    
-                                // プレーヤーの準備ができたら動画をロードする
-                                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
-                                    override fun onReady(youTubePlayer: YouTubePlayer) {
-                                        // loadVideoで自動再生を開始
-                                        youTubePlayer.loadVideo(videoIdOnly, 0f)
-                                    }
-                                })
-                            }
-                        },
-                        modifier = Modifier.fillMaxSize(),
-                        onRelease = { view ->
-                            // 画面が閉じられるときにオブザーバーを解除し、プレーヤーを完全に破棄する
-                            lifecycleOwner.lifecycle.removeObserver(view)
-                            view.release()
-                        }
-                    )
+                   VideoPlayerView(videoId = video.id)
                 } else {
                     // 運動中（WORKOUT）の表示
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
@@ -17,25 +17,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
 import android.content.Context
 import android.hardware.SensorManager
 import com.example.ry0000tarodojo2026.R
 import com.example.ry0000tarodojo2026.data.model.ExerciseType
 import com.example.ry0000tarodojo2026.data.model.VideoEntity
-import com.example.ry0000tarodojo2026.ui.components.VideoPlayerView
 import com.example.ry0000tarodojo2026.utils.ShakeDetector
 import java.util.Locale
 

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
@@ -48,6 +48,7 @@ fun TimerPlayerScreen(
     isExercisePhase: Boolean,
     exerciseType: ExerciseType,
     onBack: () -> Unit,
+    sharedBoundsModifier: Modifier = Modifier,
     videoPlayerContent: @Composable () -> Unit
 )
 {
@@ -267,6 +268,7 @@ fun TimerPlayerScreen(
                     .fillMaxWidth()
                     .aspectRatio(16 / 9f)
                     .clip(RoundedCornerShape(16.dp))
+                    .then(sharedBoundsModifier)
                     .background(MaterialTheme.colorScheme.scrim),
                 contentAlignment = Alignment.Center
             ) {

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainUiState.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainUiState.kt
@@ -3,6 +3,12 @@ package com.example.ry0000tarodojo2026.ui.viewmodel
 import com.example.ry0000tarodojo2026.data.model.ExerciseType
 import com.example.ry0000tarodojo2026.data.model.VideoEntity
 
+enum class PlayerMode{
+    HIDDEN,
+    FULL,
+    MINI
+}
+
 data class MainUiState(
     val videoList: List<VideoEntity> = emptyList(),
     val isLoading: Boolean = false,
@@ -12,5 +18,6 @@ data class MainUiState(
     val lastMinutes: String = "3",
     val exerciseSeconds: Long = 0,
     val isExercisePhase: Boolean = false,
-    val exerciseType: ExerciseType = ExerciseType.NONE
+    val exerciseType: ExerciseType = ExerciseType.NONE,
+    val playerMode: PlayerMode = PlayerMode.HIDDEN
 )

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
@@ -71,9 +71,22 @@ class MainViewModel @Inject constructor(
         val exerciseSec = (targetSeconds - videoSeconds).coerceAtLeast(0L)
         _uiState.update { it.copy(
             selectedVideo = video,
-            exerciseSeconds = exerciseSec
+            exerciseSeconds = exerciseSec,
+            playerMode = PlayerMode.FULL
         ) }
         timerManager.start(videoSeconds, exerciseSec)
+    }
+
+    fun updatePlayerMode(mode: PlayerMode){
+        _uiState.update{
+            it.copy(playerMode = mode) }
+    }
+
+    fun closePlayer(){
+        _uiState.update{it.copy(
+            selectedVideo = null,
+            playerMode =  PlayerMode.HIDDEN
+        )}
     }
 
     fun onBackToList() {

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
@@ -43,14 +43,24 @@ class MainViewModel @Inject constructor(
             timerManager.remainingSeconds,
             timerManager.isExercisePhase
         ) { videos, (query, mins, exType), seconds, isExercise ->
-            _uiState.update { it.copy(
-                videoList = videos,
-                lastQuery = query,
-                lastMinutes = mins,
-                exerciseType = exType,
-                remainingSeconds = seconds,
-                isExercisePhase = isExercise
-            ) }
+            _uiState.update { state ->
+                // 運動フェーズに突入した瞬間にミニプレイヤーならフルスクリーンに戻す
+                val newPlayerMode = if (isExercise && !state.isExercisePhase && state.playerMode == PlayerMode.MINI) {
+                    PlayerMode.FULL
+                } else {
+                    state.playerMode
+                }
+                
+                state.copy(
+                    videoList = videos,
+                    lastQuery = query,
+                    lastMinutes = mins,
+                    exerciseType = exType,
+                    remainingSeconds = seconds,
+                    isExercisePhase = isExercise,
+                    playerMode = newPlayerMode
+                )
+            }
         }.launchIn(viewModelScope)
     }
 

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
@@ -93,6 +93,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun closePlayer(){
+        timerManager.stop()
         _uiState.update{it.copy(
             selectedVideo = null,
             playerMode =  PlayerMode.HIDDEN

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ composeBom = "2024.09.00"
 foundation = "1.10.3"
 retrofit = "2.11.0"
 converter-gson = "2.11.0"
+okhttp-logging = "4.12.0"
 coil = "2.6.0"
 room = "2.7.0-alpha11"
 ksp = "2.0.21-1.0.28"
@@ -45,6 +46,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "converter-gson" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 youtube-player-core = { group = "com.pierfrancescosoffritti.androidyoutubeplayer", name = "core", version.ref = "youtube-player" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }

--- a/test_scale.kt
+++ b/test_scale.kt
@@ -1,5 +1,0 @@
-import androidx.compose.animation.SharedTransitionScope
-
-fun test() {
-    val x = SharedTransitionScope.ResizeMode.ScaleToBounds()
-}

--- a/test_scale.kt
+++ b/test_scale.kt
@@ -1,0 +1,5 @@
+import androidx.compose.animation.SharedTransitionScope
+
+fun test() {
+    val x = SharedTransitionScope.ResizeMode.ScaleToBounds()
+}


### PR DESCRIPTION
#31 
動画再生画面において、フルスクリーン（TimerPlayerScreen）とミニプレイヤー（MiniPlayerBar）のモード切り替え機能を実装しました。 切り替え時のUXを向上させるため、Composeの Shared Element Transitions（共有要素トランジション）を導入し、動画がシームレスに変形しながら移動するアニメーションを追加しています。 また、運動フェーズへの移行に伴う画面の強制切り替えロジックなども整備しました。

主な変更内容 (Changes):

⚪︎プレイヤーのモード状態管理の追加
MainUiState に列挙型 PlayerMode (FULL, MINI, HIDDEN) を新設し、画面の表示状態を定義。
MainViewModel にモードを更新・閉じるための関数 (updatePlayerMode, closePlayer) を追加。
⚪︎Shared Element Transitions の導入
PlayerOverlay に SharedTransitionLayout と AnimatedContent を導入し、画面切り替え時のアニメーションを実装。
動画プレイヤー部分を movableContentOf で保持することで、モード切り替え時にも動画の再生状態を破棄せずに維持・移動できるように変更。
⚪︎運動フェーズ開始時のUX改善
タイマーが進行し、運動フェーズ（isExercisePhase = true）に切り替わった際、現在がミニプレイヤーだった場合は強制的にフルスクリーンへ戻るロジックを MainViewModel に追加。
⚪︎UIコンポーネントの整理
フルスクリーン (TimerPlayerScreen) およびミニプレイヤー (MiniPlayerBar) の引数に sharedBoundsModifier と videoPlayerContent を追加し、状態に応じたUIの差し替えを容易にしました。
その他依存関係の追加
libs.versions.toml に okhttp-logging インターセプターを追加。