### PR TITLE
48 featアイコンの表示 

### DIFF
--- a/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/MainActivity.kt
@@ -93,6 +93,9 @@ class MainActivity : ComponentActivity() {
                                         onVideoSelect = { video ->
                                             // 画面遷移せず、状態を更新してプレイヤーを表示
                                             viewModel.onVideoSelect(video)
+                                        },
+                                        getChannelIcon = { channelId ->
+                                            viewModel.getChannelIconUrl(channelId)
                                         }
                                     )
                                 }
@@ -113,7 +116,8 @@ class MainActivity : ComponentActivity() {
                                     bottomPadding = innerPadding.calculateBottomPadding(),
                                     onCollapse = { viewModel.updatePlayerMode(PlayerMode.MINI) },
                                     onExpand = { viewModel.updatePlayerMode(PlayerMode.FULL) },
-                                    onClose = { viewModel.closePlayer() }
+                                    onClose = { viewModel.closePlayer() },
+                                    getChannelIcon = { channelId -> viewModel.getChannelIconUrl(channelId) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/api/YouTubeApiService.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/api/YouTubeApiService.kt
@@ -1,5 +1,6 @@
 package com.example.ry0000tarodojo2026.data.api
 
+import com.example.ry0000tarodojo2026.data.model.ChannelResponse
 import com.example.ry0000tarodojo2026.data.model.YouTubeSearchResponse
 import com.example.ry0000tarodojo2026.data.model.VideoDetailsResponse
 import retrofit2.http.GET
@@ -41,5 +42,11 @@ interface YouTubeApiService {
         @Query("key") apiKey: String
     ): VideoDetailsResponse
 
+    @GET("channels")
+    suspend fun getChannelDetails(
+        @Query("part") part: String = "snippet",
+        @Query("id") channelId: String,
+        @Query("key") apiKey: String
+    ): ChannelResponse
 
 }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/local/AppDatabase.kt
@@ -3,10 +3,12 @@ package com.example.ry0000tarodojo2026.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.example.ry0000tarodojo2026.data.model.VideoEntity
+import com.example.ry0000tarodojo2026.data.model.ChannelEntity
 
 // 管理するEntityとバージョンを指定
-@Database(entities = [VideoEntity::class], version = 1, exportSchema = false)
+@Database(entities = [VideoEntity::class], version = 2, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     // DAOを取得するための窓口
     abstract fun videoDao(): VideoDao
+    abstract fun channelDao(): ChannelDao
 }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/local/AppDatabase.kt
@@ -6,7 +6,7 @@ import com.example.ry0000tarodojo2026.data.model.VideoEntity
 import com.example.ry0000tarodojo2026.data.model.ChannelEntity
 
 // 管理するEntityとバージョンを指定
-@Database(entities = [VideoEntity::class], version = 2, exportSchema = false)
+@Database(entities = [VideoEntity::class, ChannelEntity::class], version = 2, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     // DAOを取得するための窓口
     abstract fun videoDao(): VideoDao

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/local/ChannelDao.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/local/ChannelDao.kt
@@ -1,0 +1,16 @@
+package com.example.ry0000tarodojo2026.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.ry0000tarodojo2026.data.model.ChannelEntity
+
+@Dao
+interface ChannelDao {
+    @Query("SELECT * FROM channels WHERE channelId = :channelId LIMIT 1")
+    suspend fun getChannelById(channelId: String): ChannelEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChannel(channel: ChannelEntity)
+}

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/local/ChannelDao.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/local/ChannelDao.kt
@@ -8,8 +8,8 @@ import com.example.ry0000tarodojo2026.data.model.ChannelEntity
 
 @Dao
 interface ChannelDao {
-    @Query("SELECT * FROM channels WHERE channelId = :channelId LIMIT 1")
-    suspend fun getChannelById(channelId: String): ChannelEntity?
+    @Query("SELECT * FROM channels WHERE channelId = :id LIMIT 1")
+    suspend fun getChannelById(id: String): ChannelEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertChannel(channel: ChannelEntity)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/model/ChannelEntity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/model/ChannelEntity.kt
@@ -1,0 +1,11 @@
+package com.example.ry0000tarodojo2026.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "channels")
+data class ChannelEntity(
+    @PrimaryKey val channelId: String,
+    val iconUrl: String,
+    val savedAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/model/ChannelResponse.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/model/ChannelResponse.kt
@@ -1,0 +1,15 @@
+package com.example.ry0000tarodojo2026.data.model
+
+data class ChannelResponse(
+    val items: List<ChannelItem>?
+)
+
+data class ChannelItem(
+    val id: String,
+    val snippet: ChannelSnippet
+)
+
+data class ChannelSnippet(
+    val title: String,
+    val thumbnails: Thumbnails
+)

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/model/VideoData.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/model/VideoData.kt
@@ -22,6 +22,7 @@ fun VideoItem.toEntity(): VideoEntity {
         title = this.snippet.title,
         thumbnailUrl = this.snippet.thumbnails.high.url,
         channelTitle = this.snippet.channelTitle,
+        channelId = this.snippet.channelId,
         duration = null, // APIの別エンドポイントが必要なため一旦null
         savedAt = System.currentTimeMillis()
     )

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/model/VideoEntity.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/model/VideoEntity.kt
@@ -10,6 +10,7 @@ data class VideoEntity(
     val title: String,
     val thumbnailUrl: String,
     val channelTitle: String,
+    val channelId: String,
     val duration: String?, // 以前話した「カップ麺の待ち時間」に合う動画選びで重要ですね
     val savedAt: Long = System.currentTimeMillis() // キャッシュの鮮度管理用
 )

--- a/app/src/main/java/com/example/ry0000tarodojo2026/data/repository/YouTubeRepository.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/data/repository/YouTubeRepository.kt
@@ -6,11 +6,15 @@ import android.util.Log
 import com.example.ry0000tarodojo2026.data.local.VideoDao
 import com.example.ry0000tarodojo2026.data.model.VideoData
 import com.example.ry0000tarodojo2026.data.model.VideoEntity
+import com.example.ry0000tarodojo2026.data.local.ChannelDao
+import com.example.ry0000tarodojo2026.data.model.ChannelEntity
+import com.example.ry0000tarodojo2026.BuildConfig
 import kotlinx.coroutines.flow.Flow
 
 class YouTubeRepository(
     private val apiService: YouTubeApiService,
-    private val dao: VideoDao
+    private val dao: VideoDao,
+    private val channelDao: ChannelDao
 
 ) {
     val allVideos: Flow<List<VideoEntity>> = dao.getAllVideos()
@@ -36,6 +40,7 @@ class YouTubeRepository(
                     title = item.snippet.title,
                     thumbnailUrl = item.snippet.thumbnails.high.url,
                     channelTitle = item.snippet.channelTitle,
+                    channelId = item.snippet.channelId,
                     duration = formatDurationString(item.contentDetails.duration),
                     savedAt = System.currentTimeMillis()
                 )
@@ -150,6 +155,30 @@ class YouTubeRepository(
         return dao.getVideoById(videoId)
     }
 
+    suspend fun getChannelIconUrl(channelId: String): String? {
+        val cached = channelDao.getChannelById(channelId)
+        if(cached != null){
+            return cached.iconUrl
+        }
+
+        return try{
+            val response = apiService.getChannelDetails(
+                channelId = channelId,
+                apiKey = BuildConfig.YOUTUBE_API_KEY
+            )
+
+            val iconUrl = response.items?.firstOrNull()?.snippet?.thumbnails?.high?.url
+
+            if (iconUrl != null) {
+                channelDao.insertChannel(ChannelEntity(channelId, iconUrl))
+            }
+            iconUrl
+        } catch (e: Exception) {
+            Log.e("YouTubeRepository", "Channel fetch error", e)
+            null
+
+        }
+    }
 
 
 }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/di/AppModule.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/di/AppModule.kt
@@ -52,7 +52,8 @@ object AppModule {
         return Room.databaseBuilder(
             context,
             AppDatabase::class.java, "youtube-db"
-        ).build()
+        ).fallbackToDestructiveMigration()
+        .build()
     }
 
     //設定ファイルの作り方を教える
@@ -66,7 +67,7 @@ object AppModule {
     @Provides
     @Singleton
     fun provideYouTubeRepository(db: AppDatabase): YouTubeRepository {
-        return YouTubeRepository(RetrofitInstance.api, db.videoDao())
+        return YouTubeRepository(RetrofitInstance.api, db.videoDao(), db.channelDao())
     }
 
     @Provides

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/PlayerOverlay.kt
@@ -30,7 +30,8 @@ fun PlayerOverlay(
     bottomPadding: Dp,
     onCollapse: () -> Unit,
     onExpand: () -> Unit,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    getChannelIcon: suspend (String) -> String?
 ) {
     val videoId = uiState.selectedVideo?.id
     val videoPlayer = remember(videoId) {
@@ -72,6 +73,7 @@ fun PlayerOverlay(
                             exerciseType = uiState.exerciseType,
                             onBack = onCollapse,
                             sharedBoundsModifier = sharedMod,
+                            getChannelIcon = getChannelIcon,
                             videoPlayerContent = {
                                 Box(
                                     modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/VideoItemRow.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/components/VideoItemRow.kt
@@ -5,6 +5,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,8 +23,12 @@ import com.example.ry0000tarodojo2026.data.model.VideoEntity
 fun VideoItemRow(
     video: VideoEntity,
     exerciseTimeText: String,
-    exerciseType: ExerciseType
+    exerciseType: ExerciseType,
+    getChannelIcon: suspend (String) -> String?
 ) {
+    val iconUrl by androidx.compose.runtime.produceState<String?>(initialValue = null, video.channelId) {
+        value = getChannelIcon(video.channelId)
+    }
     ElevatedCard(
         modifier = Modifier
             .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -53,12 +59,26 @@ fun VideoItemRow(
 
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(verticalAlignment = Alignment.Top) {
-                    Icon(
-                        imageVector = Icons.Default.AccountCircle,
-                        contentDescription = null,
-                        modifier = Modifier.size(40.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    if (iconUrl != null) {
+                        AsyncImage(
+                            model = coil.request.ImageRequest.Builder(androidx.compose.ui.platform.LocalContext.current)
+                                .data(iconUrl)
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = "Channel Icon",
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(androidx.compose.foundation.shape.CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(40.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                     Spacer(modifier = Modifier.width(12.dp))
                     Column {
                         Text(

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/SearchListScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/SearchListScreen.kt
@@ -21,7 +21,8 @@ fun SearchListScreen(
     initialQuery: String,
     isLoading: Boolean,
     onSearch: (String, Long, ExerciseType) -> Unit,
-    onVideoSelect: (VideoEntity) -> Unit
+    onVideoSelect: (VideoEntity) -> Unit,
+    getChannelIcon: suspend (String) -> String?
 ) {
     val targetSeconds = (targetMinutes.toLongOrNull() ?: 3L) * 60
 
@@ -48,7 +49,8 @@ fun SearchListScreen(
                     VideoItemRow(
                         video = video,
                         exerciseTimeText = exerciseText,
-                        exerciseType = exerciseType
+                        exerciseType = exerciseType,
+                        getChannelIcon = getChannelIcon
                     )
                 }
             }

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/screens/TimerPlayerScreen.kt
@@ -41,6 +41,7 @@ fun TimerPlayerScreen(
     exerciseType: ExerciseType,
     onBack: () -> Unit,
     sharedBoundsModifier: Modifier = Modifier,
+    getChannelIcon: suspend (String) -> String?,
     videoPlayerContent: @Composable () -> Unit
 )
 {
@@ -97,6 +98,10 @@ fun TimerPlayerScreen(
                 180L
             }
         } catch (e: Exception) { 180L }
+    }
+
+    val iconUrl by produceState<String?>(initialValue = null, video.channelId) {
+        value = getChannelIcon(video.channelId)
     }
 
     Column(
@@ -373,12 +378,26 @@ fun TimerPlayerScreen(
                     modifier = Modifier.padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.AccountCircle,
-                        contentDescription = "Channel Icon",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(40.dp)
-                    )
+                    if (iconUrl != null) {
+                        coil.compose.AsyncImage(
+                            model = coil.request.ImageRequest.Builder(LocalContext.current)
+                                .data(iconUrl)
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = "Channel Icon",
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape),
+                            contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = "Channel Icon",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(40.dp)
+                        )
+                    }
                     Spacer(modifier = Modifier.width(16.dp))
                     Column {
                         Text(

--- a/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/ry0000tarodojo2026/ui/viewmodel/MainViewModel.kt
@@ -161,4 +161,8 @@ class MainViewModel @Inject constructor(
             180L
         }
     }
+
+    suspend fun getChannelIconUrl(channelId: String): String? {
+        return repository.getChannelIconUrl(channelId)
+    }
 }


### PR DESCRIPTION
## 概要
動画リスト（`SearchListScreen`）および再生画面（`TimerPlayerScreen`）において、動画のチャンネルアイコンを表示する機能を追加しました。
APIリクエストの消費を抑えつつ高速に表示するため、Roomデータベースを用いたキャッシュ戦略（一度取得したアイコンURLをローカルに保存して再利用する仕組み）を導入しています。
## 変更内容（詳細）
- **モデル・API通信の追加**
  - YouTube APIからチャンネル情報を取得するためのエンドポイント `getChannelDetails` を `YouTubeApiService` に追加
  - レスポンスを受け取るための `ChannelResponse` データクラスを追加
- **データベース（Room）の改修**
  - アイコンのURLをキャッシュするためのテーブル `ChannelEntity` を新規作成
  - キャッシュの保存・取得を担う `ChannelDao` を作成し、`AppDatabase` に登録（DBバージョンを更新し `fallbackToDestructiveMigration` を設定）
  - 動画とチャンネルを紐付けるため、既存の `VideoEntity` および `VideoData` に `channelId` カラムを追加
- **リポジトリ（キャッシュロジック）の実装**
  - `YouTubeRepository` に `getChannelIconUrl` メソッドを追加
  - **キャッシュ戦略**: ローカルDBを確認し、URLがあればそれを返す。無ければYouTube APIにリクエストし、取得したURLをDBに保存してから返す仕組みを実装
- **UIの改善と繋ぎ込み**
  - `VideoItemRow` および `TimerPlayerScreen` の引数に `getChannelIcon` 関数を追加し、`produceState` を用いて非同期でURLを取得するように改修
  - `Coil` の `AsyncImage` を使用し、取得したURLから画像を円形にくり抜いて表示するUIを実装
  - `SearchListScreen` で動画を選択した際に、ソフトウェアキーボードが自動的に閉じるようにUXを改善
  - 画面の小さい端末やキーボードを開いた状態でも要素が隠れないよう、`TimerPlayerScreen` 全体に `verticalScroll` を追加
## 確認手順
1. アプリを起動し、任意のキーワードで動画を検索する。
2. 検索結果のリスト（`VideoItemRow`）に、各チャンネルのアイコン画像が正しく表示されることを確認する。
3. リストから動画をタップし、再生画面（`TimerPlayerScreen`）に遷移する（※このときキーボードが閉じることも確認）。
4. 再生画面の下部にあるチャンネル情報カードに、同じくチャンネルアイコンが表示されることを確認する。
5. （任意）App InspectionのDatabaseタブを開き、`channels` テーブルに `channelId` と `iconUrl` がキャッシュとして保存されていることを確認する。